### PR TITLE
Add karaoke player scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "karaoke-r3f-player",
+  "version": "1.0.0",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "rollup -c",
+    "test": "jest",
+    "lint": "eslint src/**/*.ts src/**/*.tsx",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@react-three/fiber": "^10.0.0",
+    "@react-three/drei": "^9.0.0",
+    "react-spring": "^9.4.0",
+    "tailwindcss": "^3.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^2.0.0",
+    "vite": "^4.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "jest": "^29.0.0",
+    "eslint": "^8.0.0",
+    "@rollup/plugin-typescript": "^11.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-commonjs": "^25.0.0",
+    "rollup-plugin-dts": "^5.0.0",
+    "rollup": "^3.0.0",
+    "ts-jest": "^29.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Karaoke R3F Player</title>
+  </head>
+  <body class="m-0 p-0 overflow-hidden">
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import dts from 'rollup-plugin-dts';
+
+export default [
+  {
+    input: 'src/index.tsx',
+    output: [
+      { file: 'dist/index.esm.js', format: 'esm' },
+      { file: 'dist/index.cjs.js', format: 'cjs' },
+    ],
+    plugins: [nodeResolve(), commonjs(), typescript({ jsx: 'react-jsx' })],
+    external: ['react', 'react-dom', '@react-three/fiber', '@react-three/drei'],
+  },
+  {
+    input: 'src/index.tsx',
+    output: { file: 'dist/index.d.ts', format: 'es' },
+    plugins: [dts()],
+  },
+];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { AudioProvider } from './contexts/AudioContext';
+import { LyricsProvider } from './contexts/LyricsContext';
+import { ControlsPanel } from './components/ControlsPanel';
+import { LyricsOverlay } from './components/LyricsOverlay';
+import { R3FScene } from './components/R3FScene';
+import { defaultTheme } from './themes/defaultTheme';
+
+export const App: React.FC = () => {
+  const [theme] = React.useState(defaultTheme);
+
+  return (
+    <AudioProvider>
+      <LyricsProvider>
+        <div className="w-full h-screen relative bg-gray-900 text-white">
+          <R3FScene theme={theme} />
+          <ControlsPanel />
+          <LyricsOverlay />
+        </div>
+      </LyricsProvider>
+    </AudioProvider>
+  );
+};

--- a/src/__tests__/parseLRC.test.ts
+++ b/src/__tests__/parseLRC.test.ts
@@ -1,0 +1,10 @@
+import { parseLRC } from '../utils/parseLRC';
+
+test('parses lrc lines', () => {
+  const input = '[00:10.00]hello\n[00:20.00]world';
+  const result = parseLRC(input);
+  expect(result).toEqual([
+    { time: 10, text: 'hello' },
+    { time: 20, text: 'world' },
+  ]);
+});

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { useAudio } from '../contexts/AudioContext';
+
+export const AudioPlayer: React.FC = () => {
+  const { audioRef } = useAudio();
+  return <audio ref={audioRef} />;
+};

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -1,0 +1,41 @@
+import React, { ChangeEvent } from 'react';
+import { useAudio } from '../contexts/AudioContext';
+import { useLyrics } from '../contexts/LyricsContext';
+import { useLRCParser } from '../hooks/useLRCParser';
+
+export const ControlsPanel: React.FC = () => {
+  const { audioRef } = useAudio();
+  const { setLyrics } = useLyrics();
+  const [rawLrc, setRawLrc] = React.useState<string | null>(null);
+  const parsed = useLRCParser(rawLrc);
+
+  React.useEffect(() => {
+    if (parsed.length) setLyrics(parsed);
+  }, [parsed, setLyrics]);
+
+  const onAudioChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && audioRef.current) {
+      audioRef.current.src = URL.createObjectURL(file);
+    }
+  };
+
+  const onLrcChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      file.text().then(setRawLrc);
+    }
+  };
+
+  const onPlay = () => audioRef.current?.play();
+  const onPause = () => audioRef.current?.pause();
+
+  return (
+    <div className="absolute top-4 left-4 bg-black bg-opacity-50 p-4 rounded text-sm space-x-2">
+      <input type="file" accept="audio/*" onChange={onAudioChange} />
+      <input type="file" accept=".lrc" onChange={onLrcChange} />
+      <button onClick={onPlay} className="px-2 py-1 bg-green-600 rounded">Play</button>
+      <button onClick={onPause} className="px-2 py-1 bg-red-600 rounded">Pause</button>
+    </div>
+  );
+};

--- a/src/components/LyricsOverlay.tsx
+++ b/src/components/LyricsOverlay.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useLyrics } from '../contexts/LyricsContext';
+import { useSync } from '../hooks/useSync';
+
+export const LyricsOverlay: React.FC = () => {
+  const { lyrics, activeIndex } = useLyrics();
+  useSync();
+
+  return (
+    <div className="absolute bottom-20 w-full text-center pointer-events-none font-bold text-2xl">
+      {lyrics.map((line, idx) => (
+        <div
+          key={idx}
+          className={idx === activeIndex ? 'text-yellow-300' : 'text-white'}
+          style={{ lineHeight: '2rem' }}
+        >
+          {line.text}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/R3FScene.tsx
+++ b/src/components/R3FScene.tsx
@@ -1,0 +1,35 @@
+import React, { useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Water } from '@react-three/drei';
+import * as THREE from 'three';
+
+interface Props {
+  theme: { waterNormal: string };
+}
+
+export const R3FScene: React.FC<Props> = ({ theme }) => {
+  const waterRef = useRef<THREE.Mesh>(null!);
+  useFrame(({ clock }) => {
+    if (waterRef.current) {
+      (waterRef.current.material as any).uniforms.time.value = clock.getElapsedTime();
+    }
+  });
+
+  return (
+    <Canvas shadows camera={{ position: [0, 5, 10], fov: 50 }} className="absolute inset-0">
+      <ambientLight intensity={0.3} />
+      <directionalLight position={[5, 10, 5]} intensity={1.2} castShadow />
+      <Water
+        ref={waterRef}
+        args={[10, 10]}
+        waterNormals={new THREE.TextureLoader().load(theme.waterNormal, (t) => {
+          t.wrapS = t.wrapT = THREE.RepeatWrapping;
+        })}
+        sunDirection={new THREE.Vector3(1, 1, 1)}
+        sunColor={0xffffff}
+        waterColor={0x001e0f}
+        distortionScale={3}
+      />
+    </Canvas>
+  );
+};

--- a/src/contexts/AudioContext.tsx
+++ b/src/contexts/AudioContext.tsx
@@ -1,0 +1,18 @@
+import React, { createContext, useRef, useContext } from 'react';
+
+interface AudioContextValue {
+  audioRef: React.RefObject<HTMLAudioElement>;
+}
+
+const Ctx = createContext<AudioContextValue | undefined>(undefined);
+
+export const AudioProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  return <Ctx.Provider value={{ audioRef }}>{children}<audio ref={audioRef} className="hidden" /></Ctx.Provider>;
+};
+
+export const useAudio = () => {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useAudio must be used within AudioProvider');
+  return ctx;
+};

--- a/src/contexts/LyricsContext.tsx
+++ b/src/contexts/LyricsContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from 'react';
+import { ParsedLRCLine } from '../types';
+
+interface LyricsContextValue {
+  lyrics: ParsedLRCLine[];
+  setLyrics: React.Dispatch<React.SetStateAction<ParsedLRCLine[]>>;
+  activeIndex: number;
+  setActiveIndex: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const Ctx = createContext<LyricsContextValue | undefined>(undefined);
+
+export const LyricsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [lyrics, setLyrics] = useState<ParsedLRCLine[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  return (
+    <Ctx.Provider value={{ lyrics, setLyrics, activeIndex, setActiveIndex }}>
+      {children}
+    </Ctx.Provider>
+  );
+};
+
+export const useLyrics = () => {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useLyrics must be used within LyricsProvider');
+  return ctx;
+};

--- a/src/hooks/useLRCParser.ts
+++ b/src/hooks/useLRCParser.ts
@@ -1,0 +1,13 @@
+import { useState, useEffect } from 'react';
+import { parseLRC } from '../utils/parseLRC';
+import { ParsedLRCLine } from '../types';
+
+export function useLRCParser(raw: string | null): ParsedLRCLine[] {
+  const [lines, setLines] = useState<ParsedLRCLine[]>([]);
+  useEffect(() => {
+    if (raw) {
+      setLines(parseLRC(raw));
+    }
+  }, [raw]);
+  return lines;
+}

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useLyrics } from '../contexts/LyricsContext';
+import { useAudio } from '../contexts/AudioContext';
+
+export function useSync() {
+  const { lyrics, setActiveIndex } = useLyrics();
+  const { audioRef } = useAudio();
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const onTimeUpdate = () => {
+      const current = audio.currentTime;
+      for (let i = lyrics.length - 1; i >= 0; i--) {
+        if (current >= lyrics[i].time) {
+          setActiveIndex(i);
+          break;
+        }
+      }
+    };
+    audio.addEventListener('timeupdate', onTimeUpdate);
+    return () => audio.removeEventListener('timeupdate', onTimeUpdate);
+  }, [lyrics, audioRef, setActiveIndex]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/themes/darkTheme.ts
+++ b/src/themes/darkTheme.ts
@@ -1,0 +1,6 @@
+export const darkTheme = {
+  bgGradient: ['#000000', '#333333'],
+  textColor: '#ffffff',
+  font: 'Inter, sans-serif',
+  waterNormal: '/assets/waternormals.jpg',
+};

--- a/src/themes/defaultTheme.ts
+++ b/src/themes/defaultTheme.ts
@@ -1,0 +1,6 @@
+export const defaultTheme = {
+  bgGradient: ['#1e3c72', '#2a5298'],
+  textColor: '#ffffff',
+  font: 'Inter, sans-serif',
+  waterNormal: '/assets/waternormals.jpg',
+};

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,4 @@
+export interface ParsedLRCLine {
+  time: number; // in seconds
+  text: string;
+}

--- a/src/utils/parseLRC.ts
+++ b/src/utils/parseLRC.ts
@@ -1,0 +1,18 @@
+import { ParsedLRCLine } from '../types';
+
+export function parseLRC(text: string): ParsedLRCLine[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => {
+      const match = line.match(/\[(\d+):(\d+\.\d+)\](.*)/);
+      if (match) {
+        const minutes = parseInt(match[1], 10);
+        const seconds = parseFloat(match[2]);
+        const time = minutes * 60 + seconds;
+        return { time, text: match[3].trim() };
+      }
+      return null;
+    })
+    .filter((l): l is ParsedLRCLine => l !== null)
+    .sort((a, b) => a.time - b.time);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add project scaffold with React, Tailwind, and Vite
- implement basic R3F scene, lyrics overlay, and controls panel
- add LRC parser utilities and sync hooks
- configure TypeScript, Jest, Rollup, and Tailwind
- include a simple unit test for the LRC parser

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run build --silent` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a262f5fc832785d38bfffa362d38